### PR TITLE
fix serializer.toJson can not handle item targetSchema correctly.

### DIFF
--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -46,6 +46,7 @@ export class JsonSerializer extends JsonTransform {
         for (const key in namedSchema) {
           try {
             const item = namedSchema[key];
+            const itemTargetSchema = item.type as IEmptyConstructor<any>;
             const objItem = obj[key];
             let value: any;
 
@@ -78,9 +79,9 @@ export class JsonSerializer extends JsonTransform {
               // CONSTRUCTED
               if (item.repeated) {
                 // REPEATED
-                value = objItem.map((el: any) => this.toJSON(el, { schemaName }));
+                value = objItem.map((el: any) => this.toJSON(el, { targetSchema: itemTargetSchema ,schemaName }));
               } else {
-                value = this.toJSON(objItem, { schemaName });
+                value = this.toJSON(objItem, { targetSchema: itemTargetSchema ,schemaName });
               }
             }
 


### PR DESCRIPTION
for example:
```
class CA {
    @JsonProp({type: JsonPropTypes.String , name:"n"})
   name: string
}

class CB {
    @JsonProp({type:CA})
   ca: CA 
}

var b = new CB()
b.ca = new CA()
b.ca.name = "abc"

var jsonStr = JsonSerializer.serialize(b, {targetSchema: CB})
// output :
//  { ca: { name: "abc"} }
// but that is what we want
// { ca: {n: "abc"}}
```